### PR TITLE
Use const char* for SendDebugMessage's argument

### DIFF
--- a/DisasterHelper.cpp
+++ b/DisasterHelper.cpp
@@ -278,7 +278,7 @@ void DisasterHelper::CreateMeteor()
 	TethysGame::SetMeteor(disasterLoc.x, disasterLoc.y, meteorSize);
 }
 
-void DisasterHelper::SendDebugMessage(char* message)
+void DisasterHelper::SendDebugMessage(const char* message)
 {
 	AddGameMessage(message, SoundID::sndBeep8);
 }

--- a/DisasterHelper.h
+++ b/DisasterHelper.h
@@ -195,5 +195,5 @@ private:
 	LOCATION FindVortexEndLoc(const MAP_RECT& vortexCorridor,
 		const LOCATION& startLoc, double minPercentHypotenuseTravel);
 
-	void SendDebugMessage(char* message);
+	void SendDebugMessage(const char* message);
 };


### PR DESCRIPTION
Fixes warning generated by mingw compilation. Closes issue #7.